### PR TITLE
config-api: fix error on try remove license on non-pro version

### DIFF
--- a/roles/config_api/tasks/license-api.yml
+++ b/roles/config_api/tasks/license-api.yml
@@ -1,18 +1,4 @@
 ---
-- name: Remove license
-  ansible.builtin.uri:
-    url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}/service/rest/v1/system/license"
-    method: DELETE
-    validate_certs: "{{ nexus_api_validate_certs }}"
-    user: "{{ nexus_admin_username }}"
-    password: "{{ nexus_admin_password }}"
-    force_basic_auth: true
-    timeout: "{{ nexus_api_timeout }}"
-    status_code: 204
-  when: not nexus_enable_pro_version and nexus_enforce_desired_state | bool
-  changed_when: true
-  tags: license
-
 - name: Get license information
   ansible.builtin.uri:
     url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}/service/rest/v1/system/license"
@@ -35,6 +21,20 @@
   tags:
     - license
     - always
+
+- name: Remove license
+  ansible.builtin.uri:
+    url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}/service/rest/v1/system/license"
+    method: DELETE
+    validate_certs: "{{ nexus_api_validate_certs }}"
+    user: "{{ nexus_admin_username }}"
+    password: "{{ nexus_admin_password }}"
+    force_basic_auth: true
+    timeout: "{{ nexus_api_timeout }}"
+    status_code: 204
+  when: not nexus_enable_pro_version and nexus_pro_version and nexus_enforce_desired_state | bool
+  changed_when: true
+  tags: license
 
 # Nexus API expects a license file in binary format to be uploaded
 # So we need to decode the base64 encoded license string into a file


### PR DESCRIPTION
Check that license exists before remove, because delete on non-pro version return HTTP 500 with "org.sonatype.licensing.LicensingException: Unable to verify license: There is no license certificate installed for 'Nexus'."