### PR TITLE
feat(download): add custom URL support for downloads

### DIFF
--- a/plugins/modules/download.py
+++ b/plugins/modules/download.py
@@ -36,6 +36,12 @@ options:
     required: false
     type: str
     default: x86-64
+  url:
+    description:
+      - Custom base URL to download Nexus from.
+      - Can only be used when state is 'present' and version is defined.
+    required: false
+    type: str
   dest:
     description:
       - Destination directory where the file should be saved.
@@ -72,6 +78,14 @@ EXAMPLES = '''
     dest: /path/to/download/dir
     validate_certs: false
     arch: aarch64
+
+- name: Download from a custom URL
+  cloudkrafter.nexus.download:
+    state: present
+    version: 3.78.0-1
+    url: https://some-url.tld/files
+    dest: /path/to/download/dir
+    validate_certs: true
 '''
 
 RETURN = '''
@@ -288,7 +302,7 @@ def get_possible_package_names(version, arch=None, java_version=None):
     return variants + base_names
 
 
-def get_download_url(state, version=None, arch=None, validate_certs=True):
+def get_download_url(state, version=None, arch=None, base_url=None, validate_certs=True):
     """
     Determines and returns a single download URL based on state, version and architecture.
 
@@ -302,6 +316,7 @@ def get_download_url(state, version=None, arch=None, validate_certs=True):
         state (str): Either 'latest' or 'present'
         version (str): Optional version string (required if state is 'present')
         arch (str): Optional target architecture
+        base_url (str): Optional URL to download from
         validate_certs (bool): Whether to verify SSL certificates
 
     Returns:
@@ -316,7 +331,12 @@ def get_download_url(state, version=None, arch=None, validate_certs=True):
     try:
         # Get version and valid URLs
         version = get_latest_version(validate_certs) if state == 'latest' else version
-        valid_urls = get_valid_download_urls(version, arch=arch, validate_certs=validate_certs)
+        valid_urls = get_valid_download_urls(
+            version,
+            arch=arch,
+            validate_certs=validate_certs,
+            base_url=base_url or "https://download.sonatype.com/nexus/3/"
+        )
 
         # Define URL patterns in order of precedence
         patterns = [
@@ -392,6 +412,7 @@ def main():
         state=dict(type='str', required=True, choices=['latest', 'present']),
         version=dict(type='str', required=False),
         arch=dict(type='str', required=False, default='x86-64'),
+        url=dict(type='str', required=False),
         dest=dict(type='path', required=True),
         validate_certs=dict(type='bool', required=False, default=True)
     )
@@ -405,6 +426,7 @@ def main():
     state = module.params['state']
     version = module.params.get('version')
     arch = module.params.get('arch')
+    url = module.params.get('url')
     dest = module.params['dest']
     validate_certs = module.params['validate_certs']
 
@@ -412,8 +434,22 @@ def main():
     if state == 'present' and not version:
         module.fail_json(msg="When state is 'present', the 'version' parameter must be provided.")
 
+    if url and state != 'present':
+        module.fail_json(msg="URL can only be used when state is 'present'")
+
+    if url and not version:
+        module.fail_json(msg="Version must be provided when using a custom URL")
+
     try:
-        download_url = get_download_url(state, version, arch=arch, validate_certs=validate_certs)
+        if url:
+            base_url = url.rstrip('/') + '/'
+            valid_urls = get_valid_download_urls(version, arch=arch, validate_certs=validate_certs, base_url=base_url)
+            if len(valid_urls) == 1:
+                download_url = valid_urls[0]
+            else:
+                download_url = get_download_url(state, version, arch=arch, validate_certs=validate_certs, base_url=base_url)
+        else:
+            download_url = get_download_url(state, version, arch=arch, validate_certs=validate_certs)
     except Exception as e:
         module.fail_json(msg=f"Error determining download URL: {str(e)}")
 

--- a/plugins/modules/download.py
+++ b/plugins/modules/download.py
@@ -53,6 +53,13 @@ options:
     type: bool
     default: true
     required: false
+  timeout:
+    description:
+      - Timeout in seconds for the HTTP request.
+      - This value sets both the connect and read timeouts.
+    type: int
+    default: 120
+    required: false
 author:
   - "Brian Veltman (@cloudkrafter)"
 '''
@@ -393,7 +400,7 @@ def download_file(module, url, dest, validate_certs=True):
             module.fail_json(msg=f"Failed to create destination directory: {str(e)}")
 
     # Download the file
-    response, info = fetch_url(module, url, method="GET")
+    response, info = fetch_url(module, url, method="GET", timeout=module.params['timeout'])
     status_code = info['status']
 
     if info['status'] != 200:
@@ -413,6 +420,7 @@ def main():
         version=dict(type='str', required=False),
         arch=dict(type='str', required=False, default='x86-64'),
         url=dict(type='str', required=False),
+        timeout=dict(type='int', required=False, default=120),
         dest=dict(type='path', required=True),
         validate_certs=dict(type='bool', required=False, default=True)
     )

--- a/roles/nexus_oss/README.md
+++ b/roles/nexus_oss/README.md
@@ -26,6 +26,7 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
    * [Nexus Pro](#nexus-pro)
    * [Role Variables](#role-variables)
       * [General variables](#general-variables)
+      * [Downloading Nexus](#downloading-nexus)
       * [Postgres Database](#postgres-database)
       * [Nexus HA Cluster](#nexus-ha-cluster)
       * [Secrets Encryption](#secrets-encryption)
@@ -138,24 +139,23 @@ Ansible variables, along with the default values (see `default/main.yml`) :
 ```yaml
     nexus_version: ''
     nexus_timezone: 'UTC'
-    nexus_download_url: "http://download.sonatype.com/nexus/3"
+    # nexus_download_url: <unset>
     # nexus_download_ssl_verify: <unset>
     # nexus_version_running: <unset>
 ```
 
+`nexus_timezone` is a Java Timezone name and can be useful in combinationwith `nexus_scheduled_tasks` cron expressions below.
+
+## Downloading Nexus
+
 The role will install latest nexus available version by default. You may fix the version by setting
 the `nexus_version` variable. See available versions at https://www.sonatype.com/download-oss-sonatype.
-When having a slow pull through proxy, overriding the timeout can be useful. Timeout can be set using the `nexus_download_timeout` variable:
-```yaml
-    nexus_download_timeout: 120 # in seconds.
-```
 
-
-If you fix the version and change it to a different one, the role will try to upgrade your installation.
+If you set a fixed version and change it to a different one, the role will try to upgrade your installation.
 **Make sure to change to a later version in release history**. Downgrading will fail (unless you re-install
 from scratch using the [`nexus_purge` special var](#purge-nexus))
 
-If you don't fix the version and play the role on an existing installation, the current installed version will be used
+If you don't set a fixed version and play the role on an existing installation, the current installed version will be used
 (detecting target of `{{ nexus_installation_dir}}/nexus-latest`). If you want to upgrade nexus, you will have to pass
 the special var `nexus_upgrade=true` on the ansible-playbook command line.
 See [Upgrade nexus to latest version](#upgrade-nexus-to-latest-version)
@@ -163,15 +163,26 @@ See [Upgrade nexus to latest version](#upgrade-nexus-to-latest-version)
 If you use an older version of nexus than the lastest, you should make sure you do not use features which are
 not available in the installed release (e.g. yum hosted repositories for nexus < 3.8.0, git lfs repo for nexus < 3.3.0, etc.)
 
-`nexus_timezone` is a Java Timezone name and can be useful in combinationwith `nexus_scheduled_tasks` cron expressions below.
-
-You may change the download site for packages by tuning `nexus_download_url` (e.g. closed environment,
+You may change the download site for Nexus by setting the `nexus_download_url` (e.g. closed environment,
 proxy/cache on your network...). **In this case, the automatic detection of the latest version will most likelly fail
-and you will have to fix the version to download.** If you still want to take advantage of automatic latest version detection,
-a call to `<your_custom_location>/latest-unix.tar.gz` must return an HTTP 302 redirect to the latest available version
-in your cache/proxy. If your download location uses https with a self-signed certificate (or a from a private PKI) and
-you are having troubles getting it validated (i.e. download errors in the role) and you fully trust the target
-you can set `nexus_download_ssl_verify: false`.
+and you will have to use a fixed version to download.** If you still want to take advantage of automatic latest version detection, there are two options:
+  - A call to `<nexus_download_url>/latest-unix.tar.gz` must return an HTTP 302 redirect to the latest available version
+  - set the `nexus_proxy_env_vars` to use a internet-facing proxy, omit the `nexus_download_url` and `nexus_version` variables:
+    example:
+    ```yaml
+      # nexus_download_url:
+      # nexus_version:
+      nexus_proxy_env_vars:
+        http_proxy: your-proxy:port
+        https_proxy: your-proxy:port
+        # any other common Ansible proxy setting such as; no_proxy
+    ```
+This will use Sonatype's Official Download Archive to identify and download the latest version.
+
+When having a slow pull through proxy, overriding the timeout can be useful. Timeout can be set using the `nexus_download_timeout: 300`.
+
+If your download location uses https with a self-signed certificate (or a from a private PKI) and
+you are having troubles getting it validated (i.e. download errors in the role) and you fully trust the target you can set `nexus_download_ssl_verify: false`.
 
 `nexus_version_running` is a variable used internally. **As such, it should never be set directly**
 It will exist only if nexus is currently installed on the host and will register the current version prior to running

--- a/roles/nexus_oss/README.md
+++ b/roles/nexus_oss/README.md
@@ -145,10 +145,9 @@ Ansible variables, along with the default values (see `default/main.yml`) :
 
 The role will install latest nexus available version by default. You may fix the version by setting
 the `nexus_version` variable. See available versions at https://www.sonatype.com/download-oss-sonatype.
-When having a slow pull through proxy, a retry can be useful to prevent timeouts. You can add retries to the download by setting these variables:
+When having a slow pull through proxy, overriding the timeout can be useful. Timeout can be set using the `nexus_download_timeout` variable:
 ```yaml
-    nexus_download_retries: 3 # 0 by default
-    nexus_download_delay: 15
+    nexus_download_timeout: 120 # in seconds.
 ```
 
 

--- a/roles/nexus_oss/defaults/main.yml
+++ b/roles/nexus_oss/defaults/main.yml
@@ -9,7 +9,6 @@ nexus_version_file: ""
 
 nexus_download_dir: /tmp
 nexus_local_tmp_dir: /tmp # On shared ansible controller, change this to a path you own (i.e. /home/<user>/tmp)
-nexus_download_url: https://download.sonatype.com/nexus/3
 nexus_download_retries: 0
 nexus_download_delay: 15
 nexus_os_group: nexus

--- a/roles/nexus_oss/defaults/main.yml
+++ b/roles/nexus_oss/defaults/main.yml
@@ -9,8 +9,7 @@ nexus_version_file: ""
 
 nexus_download_dir: /tmp
 nexus_local_tmp_dir: /tmp # On shared ansible controller, change this to a path you own (i.e. /home/<user>/tmp)
-nexus_download_retries: 0
-nexus_download_delay: 15
+nexus_download_timeout: 120
 nexus_os_group: nexus
 nexus_os_user: nexus
 nexus_os_user_home_dir: /home/{{ nexus_os_user }}

--- a/roles/nexus_oss/tasks/nexus_install.yml
+++ b/roles/nexus_oss/tasks/nexus_install.yml
@@ -104,6 +104,7 @@
     state: "{{ 'present' if nexus_version | length > 0 else 'latest' }}"
     version: "{{ nexus_version }}"
     dest: "{{ nexus_download_dir }}"
+    url: "{{ nexus_download_url | default(omit) }}"
     validate_certs: "{{ nexus_download_ssl_verify | default(omit) }}"
   register: __nexus_download__
   until: >

--- a/roles/nexus_oss/tasks/nexus_install.yml
+++ b/roles/nexus_oss/tasks/nexus_install.yml
@@ -107,6 +107,7 @@
     url: "{{ nexus_download_url | default(omit) }}"
     timeout: "{{ nexus_download_timeout }}"
     validate_certs: "{{ nexus_download_ssl_verify | default(omit) }}"
+  environment: "{{ nexus_proxy_env_vars | default(omit) }}"
   register: __nexus_download__
 
 - name: Ensure Nexus o/s group exists

--- a/roles/nexus_oss/tasks/nexus_install.yml
+++ b/roles/nexus_oss/tasks/nexus_install.yml
@@ -105,12 +105,9 @@
     version: "{{ nexus_version }}"
     dest: "{{ nexus_download_dir }}"
     url: "{{ nexus_download_url | default(omit) }}"
+    timeout: "{{ nexus_download_timeout }}"
     validate_certs: "{{ nexus_download_ssl_verify | default(omit) }}"
   register: __nexus_download__
-  until: >
-    (__nexus_download__.status_code == 200) or (__nexus_download__.status_code == 304)
-  retries: "{{ nexus_download_retries }}"
-  delay: "{{ nexus_download_delay }}"
   notify:
     - nexus-service-stop
 
@@ -137,7 +134,7 @@
 
 - name: Unpack Nexus download
   ansible.builtin.unarchive:
-    src: "{{ __nexus_download__.dest }}"
+    src: "{{ __nexus_download__.destination }}"
     dest: "{{ nexus_installation_dir }}"
     creates: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
     copy: false

--- a/roles/nexus_oss/tasks/nexus_install.yml
+++ b/roles/nexus_oss/tasks/nexus_install.yml
@@ -108,8 +108,6 @@
     timeout: "{{ nexus_download_timeout }}"
     validate_certs: "{{ nexus_download_ssl_verify | default(omit) }}"
   register: __nexus_download__
-  notify:
-    - nexus-service-stop
 
 - name: Ensure Nexus o/s group exists
   ansible.builtin.group:


### PR DESCRIPTION
Added a new 'url' parameter to specify a custom base URL for downloading Nexus. This option is available only when the state is 'present' and a version is defined.

The download module will find any file in the following formats, and order:
- nexus-{arch}-{version}.tar.gz
- nexus-{version}-unix.tar.gz
- nexus-unix-{version}.tar.gz
- nexus-{version}-*-unix.tar.gz

First match will be returned.

Example:
```yaml
- name: Download from a custom URL
  cloudkrafter.nexus.download:
    state: present
    version: 3.78.0-1
    url: https://internal-repo.local/releases/download/beta
    dest: /tmp
    validate_certs: true
```

Return:
```bash
localhost | CHANGED => {
    "changed": true,
    "destination": "/tmp/nexus-custom.tar.gz",
    "download_url": "https://internal-repo.local/releases/download/beta/nexus-3.78.1-01-unix.tar.gz",
    "msg": "File downloaded successfully",
    "status_code": 200
}
```