### PR TITLE
Add support for defining multiple database connections (for High Availability scenarios)

### DIFF
--- a/plugins/filter/get_host_index_in_group.py
+++ b/plugins/filter/get_host_index_in_group.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+def get_host_index_in_group(host, group):
+    """Get the index of a host within its sorted group list"""
+    if not group or host not in group:
+        return 0
+    return sorted(group).index(host)
+
+def get_direct_parent(host, groups):
+    """
+    Find the smallest group containing the host.
+    
+    Args:
+        host (str): Hostname to find
+        groups (dict): Ansible inventory groups dictionary
+        
+    Returns:
+        str: Name of the smallest group containing the host
+        
+    Raises:
+        ValueError: If multiple groups of the same size contain the host
+    """
+    # Skip special groups
+    SPECIAL_GROUPS = {'all', 'ungrouped'}
+    
+    # Find all groups containing the host
+    containing_groups = {
+        name: members
+        for name, members in groups.items()
+        if name not in SPECIAL_GROUPS and host in members
+    }
+    
+    if not containing_groups:
+        return ''
+    
+    # Group by member count
+    groups_by_size = {}
+    for name, members in containing_groups.items():
+        size = len(members)
+        if size not in groups_by_size:
+            groups_by_size[size] = []
+        groups_by_size[size].append(name)
+    
+    # Get smallest size and its groups
+    smallest_size = min(groups_by_size.keys())
+    smallest_groups = groups_by_size[smallest_size]
+    
+    # Error if multiple groups have the same smallest size
+    if len(smallest_groups) > 1:
+        raise ValueError(
+            f"Host {host} belongs to multiple groups of size {smallest_size}: "
+            f"{', '.join(smallest_groups)}. Cannot determine primary group."
+        )
+    
+    return smallest_groups[0]
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'host_index_in_group': get_host_index_in_group,
+            'direct_parent': get_direct_parent
+        }

--- a/roles/nexus_oss/README.md
+++ b/roles/nexus_oss/README.md
@@ -200,7 +200,7 @@ nexus_postgres_db_hosts:
     password: nexus
 ```
 
-When using a Postgres cluster, you can define multiple pgbouncers or databases.
+When using a Postgres cluster, you can define multiple pgbouncers.
 ```yaml
 nexus_use_postgres: true
 nexus_postgres_db_hosts:
@@ -216,9 +216,17 @@ nexus_postgres_db_hosts:
     password: nexus
 ```
 
+**IMPORTANT NOTE:** 
+
+Do NOT configure multiple database connections that point to different databases or even different Postgres instances! 
+
+You want to avoid a situation where a database write goes to one PostgreSQL instance and is followed by a read which goes to another PostgreSQL instance. The latency in replication can cause the read to fail.
+
+Pgbouncers that all point towards the same Postgres instance is fine.
+
 #### Database Connection assignment in Cluster/HA mode
 Sonatype recommends to run your Nexus instances within a single cloud region or on-premises data center.
-Therefore this role will distribute the database hosts evenly across all servers within the same `inventory group`.
+Therefore this role will distribute the pgbouncers evenly across all servers within the same `inventory group`.
 
 ```ini
 [single-instances]
@@ -249,7 +257,7 @@ nexus_postgres_db_hosts:
     password: nexus
 ```
 
-In this example the database/pgbouncer assignment will look like this:
+In this example the pgbouncer assignment will look like this:
 
 `pgbouncer-01` will be assigned to `nexus-single-01`
 

--- a/roles/nexus_oss/defaults/main.yml
+++ b/roles/nexus_oss/defaults/main.yml
@@ -38,11 +38,12 @@ nexus_cluster_enabled: false
 # If you want to use PostgreSQL as the database for NEW installations, set the following to true
 nexus_use_postgres: false
 
-nexus_postgres_db_host: localhost
-nexus_postgres_db_name: nexus
-nexus_postgres_db_port: 5432
-nexus_postgres_db_username: nexus
-nexus_postgres_db_password: nexus
+nexus_postgres_db_hosts:
+  - host: localhost
+    port: 5432
+    name: nexus
+    username: nexus
+    password: nexus
 nexus_postgres_max_lifetime: 840000
 nexus_postgres_max_pool_size: 85
 

--- a/roles/nexus_oss/tasks/enable_postgres.yml
+++ b/roles/nexus_oss/tasks/enable_postgres.yml
@@ -27,7 +27,35 @@
     mode: "0640"
   tags: nexus-postgres,nexus-migrate
 
-# Add username and password to the nexus-store.properties file in the etc directory
+- name: Get primary group and its hosts
+  ansible.builtin.set_fact:
+    nexus_group: "{{ inventory_hostname | cloudkrafter.nexus.direct_parent(groups) }}"
+    nexus_group_hosts: "{{ groups[inventory_hostname | cloudkrafter.nexus.direct_parent(groups)] | default([]) | sort }}"
+  tags: nexus-postgres,nexus-migrate
+
+- name: Show nexus group and its hosts
+  ansible.builtin.debug:
+    msg: >-
+      Nexus group {{ nexus_group }} has hosts {{ nexus_group_hosts }}
+  tags: nexus-postgres,nexus-migrate
+
+- name: Set database host for Nexus instance
+  ansible.builtin.set_fact:
+    _nxrm_selected_db_: >-
+      {{
+        nexus_postgres_db_hosts[nexus_postgres_db_host_override | default(
+          (inventory_hostname | cloudkrafter.nexus.host_index_in_group(nexus_group_hosts)) % nexus_postgres_db_hosts | length
+        )]
+      }}
+  tags: nexus-postgres,nexus-migrate
+
+- name: Show bouncer assignment
+  ansible.builtin.debug:
+    msg: >-
+      Host {{ inventory_hostname }} ({{ nexus_group }})
+      will use {{ _nxrm_selected_db_.host }}
+  tags: nexus-postgres,nexus-migrate
+
 - name: Add the username and password to the nexus-store.properties file
   ansible.builtin.lineinfile:
     path: "{{ nexus_data_dir }}/etc/fabric/nexus-store.properties"
@@ -35,9 +63,9 @@
     insertafter: "EOF"
     state: present
   loop:
-    - username={{ nexus_postgres_db_username }}
-    - password={{ nexus_postgres_db_password }}
-    - jdbcUrl=jdbc\:postgresql\://{{ nexus_postgres_db_host }}\:{{ nexus_postgres_db_port }}/{{ nexus_postgres_db_name }}
+    - username={{ _nxrm_selected_db_.username }}
+    - password={{ _nxrm_selected_db_.password }}
+    - jdbcUrl=jdbc\:postgresql\://{{ _nxrm_selected_db_.host }}\:{{ _nxrm_selected_db_.port }}/{{ _nxrm_selected_db_.name }}
     - maximumPoolSize={{ nexus_postgres_max_pool_size }}
     - advanced=maxLifetime\={{ nexus_postgres_max_lifetime }}
   tags: nexus-postgres,nexus-migrate


### PR DESCRIPTION
## This is a breaking change for environments using Postgres as their database.

This change turns the `nexus_postgres_database_host` variable into a dictionary, to add support for defining multiple postgres databases/bouncers when running Nexus and Postgres in HA.

Additionally, this change will introduce a new filter to figure out the inventory group to iterate over all hosts in the inventory group, to evenly distribute the database bouncers.

**Note:** Each Nexus instance can only connect with ONE database or pgbouncer!
That's why this change will evenly distribute the bouncers over your Nexus servers (given that they are part of the same inventory group).

```yaml
nexus_postgres_db_hosts:
  - host: localhost
    port: 5432
    name: nexus
    username: nexus
    password: nexus
``