### PR TITLE
Various fixes

### DIFF
--- a/docs/content/docs/config-api-role/ssl-truststore.md
+++ b/docs/content/docs/config-api-role/ssl-truststore.md
@@ -4,5 +4,14 @@ weight: 5
 ---
 
 ```yaml {filename="group_vars/all.yml"}
-nexus_ssl_truststore: []
+nexus_ssl_truststore:
+  certificates:
+    - name: ssl.example.com
+      pem: |
+        -----BEGIN CERTIFICATE-----
+        Cert data
+        -----END CERTIFICATE-----
+  hostnames:
+    - host: example.com
+      port: 443
 ```

--- a/roles/config_api/defaults/main.yml
+++ b/roles/config_api/defaults/main.yml
@@ -146,6 +146,12 @@ nexus_repos_maven_group: []
 
 nexus_repos_composer_proxy: []
 
+nexus_repos_nuget_hosted: []
+
+nexus_repos_nuget_proxy: []
+
+nexus_repos_nuget_group: []
+
 nexus_repos_routing_rules: []
 
 # Default user password used when creating new users. This is only used if the user does not already exist.

--- a/roles/nexus_oss/tasks/main.yml
+++ b/roles/nexus_oss/tasks/main.yml
@@ -85,6 +85,13 @@
     - provision
     - blobstores
   block:
+    - name: Create/check SSL truststores
+      ansible.builtin.include_role:
+        name: cloudkrafter.nexus.config_api
+        tasks_from: ssl-truststores.yml
+      tags: privileges
+      when: nexus_privileges | length > 0
+
     - name: Create/check ldap servers
       ansible.builtin.include_tasks: setup_ldap_each.yml
       with_items: "{{ ldap_connections }}"
@@ -121,7 +128,7 @@
             force_basic_auth: true
             validate_certs: "{{ nexus_api_validate_certs }}"
             body_format: json
-            return_content: yes
+            return_content: true
             status_code: 200
           register: __nexus_existing_blobstores__
           tags: blobstores
@@ -186,12 +193,12 @@
         force_basic_auth: true
         validate_certs: "{{ nexus_api_validate_certs }}"
         body_format: json
-        return_content: yes
+        return_content: true
         status_code: 200
       register: __nexus_existing_cleanup_policies__
       when: nexus_enable_pro_version | default(false) | bool and not cleanup_in_groovy_format | bool
       tags: cleanup
-    
+
     - name: Create configured cleanup policies using Nexus API
       ansible.builtin.include_tasks: create_cleanup_policies.yml
       vars:
@@ -200,7 +207,7 @@
         - "{{ nexus_repos_cleanup_policies | d([]) }}"
       when: not cleanup_in_groovy_format | bool and nexus_repos_cleanup_policies | length > 0 and nexus_enable_pro_version
       tags: cleanup
-    
+
     - name: Get all existing routing rules
       ansible.builtin.uri:
         url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}{{ nexus_api_context_path }}service/rest/v1/routing-rules"
@@ -210,7 +217,7 @@
         force_basic_auth: true
         validate_certs: "{{ nexus_api_validate_certs }}"
         body_format: json
-        return_content: yes
+        return_content: true
         status_code: 200
       register: __nexus_existing_routing_rules__
       tags: routing-rules
@@ -246,7 +253,7 @@
         force_basic_auth: true
         validate_certs: "{{ nexus_api_validate_certs }}"
         body_format: json
-        return_content: yes
+        return_content: true
         status_code: 200
       register: __nexus_existing_repos__
       tags: repos
@@ -299,7 +306,7 @@
         - "{{ _nexus_repos_composer_proxy | d([]) }}"
       when: nexus_use_api_for_provisioning | default(false) | bool
       tags: repos
-    
+
     # This is temporarily because BearerToken for NPM proxies can not be set using the API
     - name: Create configured NPM Proxy repositories
       ansible.builtin.include_tasks: call_script.yml
@@ -307,7 +314,7 @@
         script_name: create_repos_from_list
         call_args: "{{ _nexus_repos_npm_proxy | d([]) }}"
       tags: repos
-    
+
     # This is temporarily because when creating NPM group repos, thers a possibility it contains NPM proxies.
     # Therefor we only create NPM group repos after hosted and proxy repos have been created.
     - name: Create configured NPM group repositories using Nexus API

--- a/roles/nexus_oss/tasks/main.yml
+++ b/roles/nexus_oss/tasks/main.yml
@@ -88,7 +88,7 @@
     - name: Create/check SSL truststores
       ansible.builtin.include_role:
         name: cloudkrafter.nexus.config_api
-        tasks_from: ssl-truststores.yml
+        tasks_from: ssl-truststore-api.yml
       tags: privileges
       when: nexus_privileges | length > 0
 

--- a/roles/nexus_oss/tasks/main.yml
+++ b/roles/nexus_oss/tasks/main.yml
@@ -89,8 +89,8 @@
       ansible.builtin.include_role:
         name: cloudkrafter.nexus.config_api
         tasks_from: ssl-truststore-api.yml
-      tags: privileges
-      when: nexus_privileges | length > 0
+      tags: ssl-truststore
+      when: nexus_ssl_truststore | length > 0
 
     - name: Create/check ldap servers
       ansible.builtin.include_tasks: setup_ldap_each.yml

--- a/roles/nexus_oss/tasks/nexus_install.yml
+++ b/roles/nexus_oss/tasks/nexus_install.yml
@@ -316,19 +316,12 @@
   notify:
     - nexus-service-stop
 
-- name: Ensure nexus.rc file exists
-  ansible.builtin.file:
-    path: "{{ nexus_installation_dir }}/nexus-latest/bin/nexus.rc"
-    state: touch
-    owner: "{{ nexus_os_user }}"
-    group: "{{ nexus_os_group }}"
-    mode: "0750"
-
 - name: Set nexus user
   ansible.builtin.lineinfile:
     dest: "{{ nexus_installation_dir }}/nexus-latest/bin/nexus.rc"
     regexp: .*run_as_user=.*
     line: run_as_user="{{ nexus_os_user }}"
+    create: true
   notify:
     - nexus-service-stop
 


### PR DESCRIPTION
Hi there,

These are some various fixes I ran into when converting my setup to use this collection.

* Added missing defaults for nuget repos in `config_api`
* Added docs for `nexus_ssl_truststore`  (I only tested the `hostnames` version, I deduced the other one from the code)
* Added task to check SSL truststore content before configuring LDAP servers, I noticed that when running the `nexus_oss` role alone (`config_api` does this well) it's skipped. 
* Fixed some linter errors in nexus_oss/tasks/main.yml
* Made task for ensuring `nexus.rc` is present idempotent

I tested it by running both roles against my system with no issues :-)