### PR TITLE
chore(devcontainer): update Nexus setup and container handling

### DIFF
--- a/.devcontainer/nexus-collection/devcontainer.json
+++ b/.devcontainer/nexus-collection/devcontainer.json
@@ -60,23 +60,14 @@
 	},
 	"portsAttributes": {
 		"8081": {
-			"label": "Nexus OSS",
+			"label": "Nexus COMMUNITY",
 			"protocol": "http",
 			"onAutoForward": "notify"
-		},
-		"9081": {
-			"label": "Nexus Pro (Postgres)",
-			"protocol": "http",
-			"onAutoForward": "notify"
-		},
-		"5432": {
-			"label": "Postgres",
-			"onAutoForward": "ignore"
 		}
 	},
-	"mounts": [
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
-	],
+	// "mounts": [
+	// 	"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+	// ],
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	"remoteUser": "root"
 }

--- a/.devcontainer/nexus-collection/post-create.sh
+++ b/.devcontainer/nexus-collection/post-create.sh
@@ -7,6 +7,8 @@ python_version=$(python --version | cut -d " " -f 2)
 echo "export python_version=$python_version" >> /etc/profile
 
 # Create and activate a Python virtual environment
-echo "Creating Python virtual environment for Python $python_version"
-python3 -m venv .venv-$python_version
-source .venv-$python_version/bin/activate
+echo "Creating UV virtual environment for Python $python_version"
+curl -LsSf https://astral.sh/uv/install.sh | sh
+echo 'eval "$(uv generate-shell-completion bash)"' >> ~/.bashrc
+source ~/.bashrc
+uv sync --frozen

--- a/molecule/playbook.yml
+++ b/molecule/playbook.yml
@@ -24,10 +24,26 @@
           ansible.builtin.include_role:
             name: cloudkrafter.nexus.config_api
             tasks_from: license-api.yml
+        
+        - name: Get Nexus container name
+          community.docker.docker_host_info:
+            containers: true
+          register: nexus_container_info
+
+        - name: Set Nexus container name
+          ansible.builtin.set_fact:
+            nexus_container_name: >-
+              {{
+                nexus_container_info.containers |
+                selectattr('Image', 'defined') |
+                selectattr('Image', 'search', 'sonatype/nexus') |
+                map(attribute='Id') |
+                first
+              }}
 
         - name: Restart Nexus container
           community.docker.docker_container:
-            name: nexus3-pro
+            name: "{{ nexus_container_name }}"
             state: started
             restart: true
           changed_when: false # just to pass idempotence check


### PR DESCRIPTION
Renamed "Nexus OSS" to "Nexus COMMUNITY" in port attributes. Removed unused ports and commented out Docker socket mounts to run containers within the devcontainer instead of your local Docker socket. Improving portability for CodeSpaces.

Updated post-create script to use UV virtual environment instead of Python venv, including shell completion setup.

Enhanced playbook with dynamic Nexus container name retrieval using Docker host info, improving flexibility in container management in dev/test environments.