### PR TITLE
feat(download): support direct .tar.gz URL downloads

### DIFF
--- a/plugins/modules/download.py
+++ b/plugins/modules/download.py
@@ -504,10 +504,9 @@ def main():
 
                 # Try to extract version from filename or use 'custom'
                 filename = url.split('/')[-1]
-                if 'nexus-' in filename and '.tar.gz' in filename:
-                    # Try to extract version using regex
-                    version_match = re.search(r'nexus-.*?-(\d+\.\d+\.\d+-\d+)[-.]', filename)
-                    actual_version = version_match.group(1) if version_match else "custom"
+                version_match = re.search(r'nexus-.*?(\d+\.\d+\.\d+-\d+)', filename)
+                if version_match:
+                    actual_version = version_match.group(1)
                 else:
                     actual_version = "custom"
             else:

--- a/plugins/modules/download.py
+++ b/plugins/modules/download.py
@@ -39,7 +39,10 @@ options:
   url:
     description:
       - Custom base URL to download Nexus from.
+      - If the URL ends with '.tar.gz', it will be used directly as the download URL.
+      - Otherwise, it will be used as a base URL to find package files.
       - Can only be used when state is 'present' and version is defined.
+      - Version parameter is required if URL doesn't end with '.tar.gz'.
     required: false
     type: str
   dest:
@@ -85,6 +88,13 @@ EXAMPLES = '''
     dest: /path/to/download/dir
     validate_certs: false
     arch: aarch64
+
+- name: Download from a direct URL
+  cloudkrafter.nexus.download:
+    state: present
+    url: https://example.com/nexus-3.78.0-01-unix.tar.gz
+    dest: /path/to/download/dir
+    validate_certs: true
 
 - name: Download from a custom URL
   cloudkrafter.nexus.download:
@@ -420,6 +430,9 @@ def validate_parameters(module, state, version, url):
     Validates module parameters in a specific order.
     Returns (is_valid, error_message) tuple.
     """
+    # Direct URL to .tar.gz file check
+    is_direct_url = url and url.lower().endswith('.tar.gz')
+
     # Order of validation checks
     validations = [
         # URL state check
@@ -429,13 +442,13 @@ def validate_parameters(module, state, version, url):
         ),
         # URL version check
         (
-            url and not version,
-            "Version must be provided when using a custom URL"
+            url and not is_direct_url and not version,
+            "Version must be provided when using a custom URL that doesn't point directly to a .tar.gz file"
         ),
         # Present state version check
         (
-            state == 'present' and not version,
-            "When state is 'present', the 'version' parameter must be provided."
+            state == 'present' and not version and not is_direct_url,
+            "When state is 'present', the 'version' parameter must be provided unless URL points directly to a .tar.gz file."
         )
     ]
 
@@ -480,15 +493,33 @@ def main():
 
     try:
         if url:
-            base_url = url.rstrip('/') + '/'
-            actual_version = version  # We know version is set when url is used
-            valid_urls = get_valid_download_urls(
-                actual_version, arch=arch, validate_certs=validate_certs, base_url=base_url)
-            if len(valid_urls) == 1:
-                download_url = valid_urls[0]
+            if url.lower().endswith('.tar.gz'):
+                # Direct URL to a .tar.gz file
+                download_url = url
+
+                # Validate that the URL exists
+                is_valid, status_code = validate_download_url(download_url, validate_certs)
+                if not is_valid:
+                    raise ValueError(f"The provided URL {download_url} is not accessible")
+
+                # Try to extract version from filename or use 'custom'
+                filename = url.split('/')[-1]
+                if 'nexus-' in filename and '.tar.gz' in filename:
+                    # Try to extract version using regex
+                    version_match = re.search(r'nexus-.*?-(\d+\.\d+\.\d+-\d+)[-.]', filename)
+                    actual_version = version_match.group(1) if version_match else "custom"
+                else:
+                    actual_version = "custom"
             else:
-                download_url = get_download_url(
-                    state, actual_version, arch=arch, validate_certs=validate_certs, base_url=base_url)
+                base_url = url.rstrip('/') + '/'
+                actual_version = version  # We know version is set when url is used
+                valid_urls = get_valid_download_urls(
+                    actual_version, arch=arch, validate_certs=validate_certs, base_url=base_url)
+                if len(valid_urls) == 1:
+                    download_url = valid_urls[0]
+                else:
+                    download_url = get_download_url(
+                        state, actual_version, arch=arch, validate_certs=validate_certs, base_url=base_url)
         else:
             # For non-custom URLs, get latest version if needed
             actual_version = version if state == 'present' else get_latest_version(

--- a/tests/unit/plugins/modules/test_download.py
+++ b/tests/unit/plugins/modules/test_download.py
@@ -975,7 +975,7 @@ def test_direct_url_download(mock_module, mock_validate, mock_download):
 
     # Verify URL was validated
     mock_validate.assert_called_with(
-        'https://custom-server.com/path/nexus-3.78.0-01-unix.tar.gz', 
+        'https://custom-server.com/path/nexus-3.78.0-01-unix.tar.gz',
         True
     )
 
@@ -992,6 +992,34 @@ def test_direct_url_download(mock_module, mock_validate, mock_download):
         changed=True,
         download_url='https://custom-server.com/path/nexus-3.78.0-01-unix.tar.gz',
         version='3.78.0-01',  # Extracted from filename
+        msg="File downloaded successfully",
+        destination="/tmp/custom-nexus.tar.gz",
+        status_code=200
+    )
+
+    #################################
+    # Test custom .tar.gz URL without extractable version
+    #################################
+    module_instance.reset_mock()
+    mock_validate.reset_mock()
+    mock_download.reset_mock()
+
+    # Setup for custom filename without version
+    module_instance.params = {
+        'state': 'present',
+        'url': 'https://custom-server.com/path/custom-nexus.tar.gz',
+        'dest': '/tmp',
+        'validate_certs': True,
+        'timeout': 30
+    }
+
+    main()
+
+    # Verify version is set to "custom" when not extractable
+    module_instance.exit_json.assert_called_with(
+        changed=True,
+        download_url='https://custom-server.com/path/custom-nexus.tar.gz',
+        version='custom',  # Default when version not extractable
         msg="File downloaded successfully",
         destination="/tmp/custom-nexus.tar.gz",
         status_code=200

--- a/tests/unit/plugins/modules/test_download.py
+++ b/tests/unit/plugins/modules/test_download.py
@@ -497,7 +497,7 @@ def test_main(mock_module, mock_get_latest, mock_get_url, mock_download):
 
     main()
     module_instance.fail_json.assert_called_with(
-        msg="When state is 'present', the 'version' parameter must be provided."
+        msg="When state is 'present', the 'version' parameter must be provided unless URL points directly to a .tar.gz file."
     )
 
     #################################
@@ -593,7 +593,7 @@ def test_main(mock_module, mock_get_latest, mock_get_url, mock_download):
 
     main()
     module_instance.fail_json.assert_called_with(
-        msg="Version must be provided when using a custom URL"
+        msg="Version must be provided when using a custom URL that doesn't point directly to a .tar.gz file"
     )
 
     #################################

--- a/tests/unit/plugins/modules/test_download.py
+++ b/tests/unit/plugins/modules/test_download.py
@@ -1048,7 +1048,7 @@ def test_direct_url_download(mock_module, mock_validate, mock_download):
     module_instance.fail_json.assert_called_with(
         msg="Error determining download URL: The provided URL https://custom-server.com/path/nonexistent.tar.gz is not accessible",
         download_url='https://custom-server.com/path/nonexistent.tar.gz',
-        version='custom'
+        version=None
     )
 
     #################################

--- a/tests/unit/plugins/modules/test_download.py
+++ b/tests/unit/plugins/modules/test_download.py
@@ -943,3 +943,99 @@ def test_get_download_url(mock_get_valid_urls):
             arch='x86-64',
             validate_certs=True
         )
+
+
+@patch('ansible_collections.cloudkrafter.nexus.plugins.modules.download.download_file')
+@patch('ansible_collections.cloudkrafter.nexus.plugins.modules.download.validate_download_url')
+@patch('ansible_collections.cloudkrafter.nexus.plugins.modules.download.AnsibleModule')
+def test_direct_url_download(mock_module, mock_validate, mock_download):
+    """Test direct URL download functionality"""
+    # Setup module mock
+    module_instance = setup_ansible_module_mock(mock_module)
+
+    # Setup validation mock to return success
+    mock_validate.return_value = (True, 200)
+
+    # Setup download mock
+    mock_download.return_value = (
+        True, "File downloaded successfully", "/tmp/custom-nexus.tar.gz", 200)
+
+    #################################
+    # Test direct .tar.gz URL
+    #################################
+    module_instance.params = {
+        'state': 'present',
+        'url': 'https://custom-server.com/path/nexus-3.78.0-01-unix.tar.gz',
+        'dest': '/tmp',
+        'validate_certs': True,
+        'timeout': 30
+    }
+
+    main()
+
+    # Verify URL was validated
+    mock_validate.assert_called_with(
+        'https://custom-server.com/path/nexus-3.78.0-01-unix.tar.gz', 
+        True
+    )
+
+    # Verify direct URL was used (no URL resolution needed)
+    mock_download.assert_called_with(
+        module_instance,
+        'https://custom-server.com/path/nexus-3.78.0-01-unix.tar.gz',
+        '/tmp',
+        True
+    )
+
+    # Verify version was extracted from filename
+    module_instance.exit_json.assert_called_with(
+        changed=True,
+        download_url='https://custom-server.com/path/nexus-3.78.0-01-unix.tar.gz',
+        version='3.78.0-01',  # Extracted from filename
+        msg="File downloaded successfully",
+        destination="/tmp/custom-nexus.tar.gz",
+        status_code=200
+    )
+
+    #################################
+    # Test direct URL validation failure
+    #################################
+    module_instance.reset_mock()
+    mock_validate.reset_mock()
+    mock_download.reset_mock()
+
+    # Setup for URL validation failure
+    mock_validate.return_value = (False, 404)
+    module_instance.params = {
+        'state': 'present',
+        'url': 'https://custom-server.com/path/nonexistent.tar.gz',
+        'dest': '/tmp',
+        'validate_certs': True,
+        'timeout': 30
+    }
+
+    main()
+
+    # Verify failure handling
+    module_instance.fail_json.assert_called_with(
+        msg="Error determining download URL: The provided URL https://custom-server.com/path/nonexistent.tar.gz is not accessible",
+        download_url='https://custom-server.com/path/nonexistent.tar.gz',
+        version='custom'
+    )
+
+    #################################
+    # Test direct URL with latest state (should fail)
+    #################################
+    module_instance.reset_mock()
+    module_instance.params = {
+        'state': 'latest',
+        'url': 'https://custom-server.com/path/nexus.tar.gz',
+        'dest': '/tmp',
+        'validate_certs': True
+    }
+
+    main()
+
+    module_instance.fail_json.assert_called_with(
+        msg="URL can only be used when state is 'present'"
+    )


### PR DESCRIPTION
Added functionality to handle direct download URLs ending with '.tar.gz'.
- Updated validation logic to check for direct URLs and bypass version requirement.
- Add example usage with a direct URL scenario.
- Implemented extraction of version from the filename if possible.
- Added tests for direct URL download, including success and failure cases.