### PR TITLE
Uses template for nexus-store.properties

### DIFF
--- a/roles/nexus_oss/tasks/enable_postgres.yml
+++ b/roles/nexus_oss/tasks/enable_postgres.yml
@@ -51,7 +51,7 @@
   ansible.builtin.template:
     src: nexus-store.properties.j2
     dest: "{{ nexus_data_dir }}/etc/fabric/nexus-store.properties"
-    backup: yes
+    backup: true
     owner: "{{ nexus_os_user }}"
     group: "{{ nexus_os_group }}"
     mode: "0640"

--- a/roles/nexus_oss/tasks/enable_postgres.yml
+++ b/roles/nexus_oss/tasks/enable_postgres.yml
@@ -18,15 +18,6 @@
     mode: "0750"
   tags: nexus-postgres,nexus-migrate
 
-- name: Create {{ nexus_data_dir }}/etc/fabric/nexus-store.properties file
-  ansible.builtin.file:
-    state: touch
-    dest: "{{ nexus_data_dir }}/etc/fabric/nexus-store.properties"
-    owner: "{{ nexus_os_user }}"
-    group: "{{ nexus_os_group }}"
-    mode: "0640"
-  tags: nexus-postgres,nexus-migrate
-
 - name: Get primary group and its hosts
   ansible.builtin.set_fact:
     nexus_group: "{{ inventory_hostname | cloudkrafter.nexus.direct_parent(groups) }}"
@@ -56,18 +47,14 @@
       will use {{ _nxrm_selected_db_.host }}
   tags: nexus-postgres,nexus-migrate
 
-- name: Add the username and password to the nexus-store.properties file
-  ansible.builtin.lineinfile:
-    path: "{{ nexus_data_dir }}/etc/fabric/nexus-store.properties"
-    line: "{{ item }}"
-    insertafter: "EOF"
-    state: present
-  loop:
-    - username={{ _nxrm_selected_db_.username }}
-    - password={{ _nxrm_selected_db_.password }}
-    - jdbcUrl=jdbc\:postgresql\://{{ _nxrm_selected_db_.host }}\:{{ _nxrm_selected_db_.port }}/{{ _nxrm_selected_db_.name }}
-    - maximumPoolSize={{ nexus_postgres_max_pool_size }}
-    - advanced=maxLifetime\={{ nexus_postgres_max_lifetime }}
+- name: Generate nexus-store.properties from template
+  ansible.builtin.template:
+    src: nexus-store.properties.j2
+    dest: "{{ nexus_data_dir }}/etc/fabric/nexus-store.properties"
+    backup: yes
+    owner: "{{ nexus_os_user }}"
+    group: "{{ nexus_os_group }}"
+    mode: "0640"
   tags: nexus-postgres,nexus-migrate
 
 - name: Start Nexus service

--- a/roles/nexus_oss/templates/nexus-store.properties.j2
+++ b/roles/nexus_oss/templates/nexus-store.properties.j2
@@ -1,0 +1,6 @@
+# Database configuration
+username={{ _nxrm_selected_db_.username }}
+password={{ _nxrm_selected_db_.password }}
+jdbcUrl=jdbc:postgresql://{{ _nxrm_selected_db_.host }}:{{ _nxrm_selected_db_.port }}/{{ _nxrm_selected_db_.name }}
+maximumPoolSize={{ nexus_postgres_max_pool_size }}
+advanced=maxLifetime={{ nexus_postgres_max_lifetime }}


### PR DESCRIPTION
Replaces the lineinfile task with a template for generating the nexus-store.properties file. This change simplifies the configuration process and ensures that all necessary properties are present in the correct format.