### PR TITLE
Fix Debian packages for selinux

### DIFF
--- a/roles/nexus_oss/tasks/selinux-Debian.yml
+++ b/roles/nexus_oss/tasks/selinux-Debian.yml
@@ -5,5 +5,6 @@
     update_cache: true
     state: present
   with_items:
-    - python-selinux
-    - python-semanage
+    - python3-selinux
+    - python3-semanage
+


### PR DESCRIPTION
There is no python-selinux and python-semanage in the debian's repositories but only python3 packages.