### PR TITLE
[SECURITY] - Hide ldap parameters in logs

### DIFF
--- a/roles/nexus_oss/tasks/main.yml
+++ b/roles/nexus_oss/tasks/main.yml
@@ -82,6 +82,8 @@
     - name: Create/check ldap servers
       ansible.builtin.include_tasks: setup_ldap_each.yml
       with_items: "{{ ldap_connections }}"
+      loop_control:
+        label: '{{ item.ldap_name }}'
 
     - name: Create/check content selectors
       ansible.builtin.include_tasks: call_script.yml


### PR DESCRIPTION
Hide passwords from loop for ldap settings.