### PR TITLE
Exclude log dir from test nexus data dir

### DIFF
--- a/roles/nexus_oss/tasks/nexus_install.yml
+++ b/roles/nexus_oss/tasks/nexus_install.yml
@@ -430,6 +430,7 @@
       - "{{ nexus_data_dir }}"
     excludes:
       - lost+found
+      - log
     recurse: false
     file_type: any
   register: nexus_data_dir_contents


### PR DESCRIPTION
Add log to exclude list in the check of data directory.
If the logs are in other partition you need to create the directory before installing Nexus.