### PR TITLE
Fix owner and group for nexus.rc file

### DIFF
--- a/roles/nexus_oss/tasks/nexus_install.yml
+++ b/roles/nexus_oss/tasks/nexus_install.yml
@@ -354,6 +354,8 @@
     regexp: .*run_as_user=.*
     line: run_as_user="{{ nexus_os_user }}"
     create: true
+    owner: "{{ nexus_os_user }}"
+    group: "{{ nexus_os_group }}"
   notify:
     - nexus-service-stop
 


### PR DESCRIPTION
Sometimes the owner and group is not correctly initialized. Fix this.