### PR TITLE
Add nexus_backup_db_task_id for h2 databases

### DIFF
--- a/roles/nexus_oss/defaults/main.yml
+++ b/roles/nexus_oss/defaults/main.yml
@@ -61,6 +61,7 @@ nexus_max_direct_memory: "{{ nexus_min_heap_size }}"
 # (aka -Xms -Xmx and -XX:MaxDirectMemorySize=)
 nexus_custom_jvm_settings: []
 # Nexus Backup
+nexus_backup_db_task_id: db.backup # Set to h2.backup.task for h2 databases
 nexus_backup_dir: /var/nexus-backup
 nexus_backup_dir_create: true # Shall we create the dir, or do you already have something in place?
 nexus_restore_log: "{{ nexus_backup_dir }}/nexus-restore.log"

--- a/roles/nexus_oss/templates/backup.groovy.j2
+++ b/roles/nexus_oss/templates/backup.groovy.j2
@@ -71,7 +71,7 @@ try {
 
     log.info("Create a temporary task to backup nexus db in {}/db", CurrentBackupDirPath)
     TaskScheduler taskScheduler = container.lookup(TaskScheduler.class.getName())
-    TaskConfiguration tempBackupTaskConfiguration = taskScheduler.createTaskConfigurationInstance('db.backup')
+    TaskConfiguration tempBackupTaskConfiguration = taskScheduler.createTaskConfigurationInstance("{{ nexus_backup_db_task_id }}")
     tempBackupTaskConfiguration.setName('Temporary db.backup task')
     tempBackupTaskConfiguration.setString('location', CurrentBackupDirPath+'/db')
     Schedule schedule = taskScheduler.scheduleFactory.manual()


### PR DESCRIPTION
Add var to backup task. Needed for h2 database backups.