### PR TITLE
Adhere to certificate validation setting in nexus_api

### DIFF
--- a/roles/config_api/tasks/main.yml
+++ b/roles/config_api/tasks/main.yml
@@ -4,6 +4,7 @@
     url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}"
     username: "{{ nexus_admin_username }}"
     password: "{{ nexus_admin_password }}"
+    validate_certs: "{{ nexus_api_validate_certs }}"
   register: nxrm_instance
   tags: always
 


### PR DESCRIPTION
The `gather_info` task in nexus_api role is missing the `validate_certs` property and fails on self-signed installations